### PR TITLE
fix: avoid infinite loops + optimizations

### DIFF
--- a/src/classes.js
+++ b/src/classes.js
@@ -1,17 +1,26 @@
-'use strict';
+"use strict";
 
-import {toPadding, resolve} from 'chart.js/helpers';
-import positioners from './positioners.js';
-import {textSize, parseFont} from './custom-helpers';
-import customDefaults from './custom-defaults.js';
+import { toPadding, resolve } from "chart.js/helpers";
+import positioners from "./positioners.js";
+import { textSize, parseFont } from "./custom-helpers";
+import customDefaults from "./custom-defaults.js";
 
 var PLUGIN_KEY = customDefaults.PLUGIN_KEY;
 
+function collides(rect, otherRect) {
+  return (
+    rect.x < otherRect.x + otherRect.width &&
+    rect.x + rect.width > otherRect.x &&
+    rect.y < otherRect.y + otherRect.height &&
+    rect.y + rect.height > otherRect.y
+  );
+}
+
 export default {
-  OutLabel: function(chart, index, ctx, config, context) {
+  OutLabel: function (chart, index, ctx, config, context) {
     // Check whether the label should be displayed
     if (!resolve([config.display, true], context, index)) {
-      throw new Error('Label display property is set to false.');
+      throw new Error("Label display property is set to false.");
     }
 
     // Init text
@@ -22,26 +31,33 @@ export default {
     text = text.replace(/%l/gi, label);
 
     /* Replace value marker with possible precision value */
-    (text.match(/%v\.?(\d*)/gi) || []).map(function(val) {
-      var prec = val.replace(/%v\./gi, '');
-      if (prec.length) {
-        return +prec;
-      }
-      return config.valuePrecision || customDefaults.valuePrecision;
-    }).forEach(function(val) {
-      text = text.replace(/%v\.?(\d*)/i, value.toFixed(val));
-    });
+    (text.match(/%v\.?(\d*)/gi) || [])
+      .map(function (val) {
+        var prec = val.replace(/%v\./gi, "");
+        if (prec.length) {
+          return +prec;
+        }
+        return config.valuePrecision || customDefaults.valuePrecision;
+      })
+      .forEach(function (val) {
+        text = text.replace(/%v\.?(\d*)/i, value.toFixed(val));
+      });
 
     /* Replace percent marker with possible precision value */
-    (text.match(/%p\.?(\d*)/gi) || []).map(function(val) {
-      var prec = val.replace(/%p\./gi, '');
-      if (prec.length) {
-        return +prec;
-      }
-      return config.percentPrecision || customDefaults.percentPrecision;
-    }).forEach(function(val) {
-      text = text.replace(/%p\.?(\d*)/i, (context.percent * 100).toFixed(val) + '%');
-    });
+    (text.match(/%p\.?(\d*)/gi) || [])
+      .map(function (val) {
+        var prec = val.replace(/%p\./gi, "");
+        if (prec.length) {
+          return +prec;
+        }
+        return config.percentPrecision || customDefaults.percentPrecision;
+      })
+      .forEach(function (val) {
+        text = text.replace(
+          /%p\.?(\d*)/i,
+          (context.percent * 100).toFixed(val) + "%"
+        );
+      });
 
     // Count lines
     var lines = text.match(/[^\r\n]+/g) || [];
@@ -52,7 +68,7 @@ export default {
     }
 
     /* ===================== CONSTRUCTOR ==================== */
-    this.init = function(text, lines) {
+    this.init = function (text, lines) {
       // If everything ok -> begin initializing
       this.encodedText = config.text;
       this.text = text;
@@ -63,35 +79,66 @@ export default {
 
       // Init style
       this.style = {
-        backgroundColor: resolve([config.backgroundColor, customDefaults.backgroundColor, 'black'], context, index),
-        borderColor: resolve([config.borderColor, customDefaults.borderColor, 'black'], context, index),
+        backgroundColor: resolve(
+          [config.backgroundColor, customDefaults.backgroundColor, "black"],
+          context,
+          index
+        ),
+        borderColor: resolve(
+          [config.borderColor, customDefaults.borderColor, "black"],
+          context,
+          index
+        ),
         borderRadius: resolve([config.borderRadius, 0], context, index),
         borderWidth: resolve([config.borderWidth, 0], context, index),
         lineWidth: resolve([config.lineWidth, 2], context, index),
-        lineColor: resolve([config.lineColor, customDefaults.lineColor, 'black'], context, index),
-        color: resolve([config.color, 'white'], context, index),
-        font: parseFont(resolve([config.font, {resizable: true}]), ctx.canvas.style.height.slice(0, -2)),
+        lineColor: resolve(
+          [config.lineColor, customDefaults.lineColor, "black"],
+          context,
+          index
+        ),
+        color: resolve([config.color, "white"], context, index),
+        font: parseFont(
+          resolve([config.font, { resizable: true }]),
+          ctx.canvas.style.height.slice(0, -2)
+        ),
         padding: toPadding(resolve([config.padding, 0], context, index)),
-        textAlign: resolve([config.textAlign, 'left'], context, index),
+        textAlign: resolve([config.textAlign, "left"], context, index),
       };
 
-      this.stretch = resolve([config.stretch, customDefaults.stretch], context, index);
-      this.horizontalStrechPad = resolve([config.horizontalStrechPad, customDefaults.horizontalStrechPad], context, index);
+      this.stretch = resolve(
+        [config.stretch, customDefaults.stretch],
+        context,
+        index
+      );
+      this.horizontalStrechPad = resolve(
+        [config.horizontalStrechPad, customDefaults.horizontalStrechPad],
+        context,
+        index
+      );
       this.size = textSize(ctx, this.lines, this.style.font);
 
       this.offsetStep = this.size.width / 20;
       this.offset = {
         x: 0,
-        y: 0
+        y: 0,
       };
     };
 
     this.init(text, lines);
 
     /* COMPUTING RECTS PART */
-    this.computeLabelRect = function() {
-      var width = this.textRect.width + 2 * this.style.borderWidth + this.style.padding.left + this.style.padding.right;
-      var height = this.textRect.height + 2 * this.style.borderWidth + this.style.padding.top + this.style.padding.bottom;
+    this.computeLabelRect = function () {
+      var width =
+        this.textRect.width +
+        2 * this.style.borderWidth +
+        this.style.padding.left +
+        this.style.padding.right;
+      var height =
+        this.textRect.height +
+        2 * this.style.borderWidth +
+        this.style.padding.top +
+        this.style.padding.bottom;
 
       var x = this.textRect.x - this.style.borderWidth;
       var y = this.textRect.y - this.style.borderWidth;
@@ -102,57 +149,29 @@ export default {
         width: width,
         height: height,
         isLeft: this.textRect.isLeft,
-        isTop: this.textRect.isTop
+        isTop: this.textRect.isTop,
       };
     };
 
-    this.computeTextRect = function() {
+    this.computeTextRect = function () {
       const isLeft = this.center.x - this.center.anchor.x < 0;
       const isTop = this.center.y - this.center.anchor.y < 0;
-      const shift = isLeft ? -(this.horizontalStrechPad + this.size.width) : this.horizontalStrechPad;
+      const shift = isLeft
+        ? -(this.horizontalStrechPad + this.size.width)
+        : this.horizontalStrechPad;
       return {
         x: this.center.x - this.style.padding.left + shift,
-        y: this.center.y - (this.size.height / 2),
+        y: this.center.y - this.size.height / 2,
         width: this.size.width,
         height: this.size.height,
         isLeft,
-        isTop
+        isTop,
       };
     };
 
-    this.getPoints = function() {
-      return [
-        {
-          x: this.labelRect.x,
-          y: this.labelRect.y
-        },
-        {
-          x: this.labelRect.x + this.labelRect.width,
-          y: this.labelRect.y
-        },
-        {
-          x: this.labelRect.x + this.labelRect.width,
-          y: this.labelRect.y + this.labelRect.height
-        },
-        {
-          x: this.labelRect.x,
-          y: this.labelRect.y + this.labelRect.height
-        }
-      ];
-    };
-
-    this.containsPoint = function(point) {
-      let offset = 5;
-
-      return	this.labelRect.x - offset <= point.x && point.x <= this.labelRect.x + this.labelRect.width + offset
-							&&
-						this.labelRect.y - offset <= point.y && point.y <= this.labelRect.y + this.labelRect.height + offset;
-    };
-
-
     /* ======================= DRAWING ======================= */
     // Draw label text
-    this.drawText = function() {
+    this.drawText = function () {
       var align = this.style.textAlign;
       var font = this.style.font;
       var lh = font.lineHeight;
@@ -167,16 +186,16 @@ export default {
       x = this.textRect.x;
       y = this.textRect.y + lh / 2;
 
-      if (align === 'center') {
+      if (align === "center") {
         x += this.textRect.width / 2;
-      } else if (align === 'end' || align === 'right') {
+      } else if (align === "end" || align === "right") {
         x += this.textRect.width;
       }
 
       this.ctx.font = this.style.font.string;
       this.ctx.fillStyle = color;
       this.ctx.textAlign = align;
-      this.ctx.textBaseline = 'middle';
+      this.ctx.textBaseline = "middle";
 
       for (idx = 0; idx < ilen; ++idx) {
         this.ctx.fillText(
@@ -189,15 +208,18 @@ export default {
       }
     };
 
-    this.ccw = function(A, B, C) {
+    this.ccw = function (A, B, C) {
       return (C.y - A.y) * (B.x - A.x) > (B.y - A.y) * (C.x - A.x);
     };
 
-    this.intersects = function(A, B, C, D) {
-      return this.ccw(A, C, D) !== this.ccw(B, C, D) && this.ccw(A, B, C) !== this.ccw(A, B, D);
+    this.intersects = function (A, B, C, D) {
+      return (
+        this.ccw(A, C, D) !== this.ccw(B, C, D) &&
+        this.ccw(A, B, C) !== this.ccw(A, B, D)
+      );
     };
 
-    this.drawLine = function() {
+    this.drawLine = function () {
       if (!this.lines.length) {
         return;
       }
@@ -205,7 +227,7 @@ export default {
 
       this.ctx.strokeStyle = this.style.lineColor;
       this.ctx.lineWidth = this.style.lineWidth;
-      this.ctx.lineJoin = 'miter';
+      this.ctx.lineJoin = "miter";
       this.ctx.beginPath();
       this.ctx.moveTo(this.center.anchor.x, this.center.anchor.y);
       this.ctx.lineTo(this.center.copy.x, this.center.copy.y);
@@ -214,37 +236,43 @@ export default {
       this.ctx.beginPath();
       this.ctx.moveTo(this.center.copy.x, this.center.copy.y);
       const xOffset = this.textRect.width + this.style.padding.width;
-      const intersect = this.intersects(this.textRect, {
-        x: this.textRect.x + this.textRect.width,
-        y: this.textRect.y + this.textRect.height,
-      }, this.center.copy, {
-        x: this.textRect.x,
-        y: this.textRect.y + this.textRect.height / 2
-      });
-      this.ctx.lineTo(this.textRect.x + (intersect ? xOffset : 0), this.textRect.y + this.textRect.height / 2);
+      const intersect = this.intersects(
+        this.textRect,
+        {
+          x: this.textRect.x + this.textRect.width,
+          y: this.textRect.y + this.textRect.height,
+        },
+        this.center.copy,
+        {
+          x: this.textRect.x,
+          y: this.textRect.y + this.textRect.height / 2,
+        }
+      );
+      this.ctx.lineTo(
+        this.textRect.x + (intersect ? xOffset : 0),
+        this.textRect.y + this.textRect.height / 2
+      );
       this.ctx.stroke();
       this.ctx.restore();
     };
 
-    this.draw = function() {
+    this.draw = function () {
       if (chart.getDataVisibility(index)) {
         this.drawText();
         this.drawLine();
       }
     };
 
-
     // eslint-disable-next-line max-statements
-    this.update = function(view, elements, max) {
+    this.update = function (view, elements, max) {
       this.center = positioners.center(view, this.stretch);
 
-      var valid = false;
+      let valid = false;
+      let steps = 30;
 
-      while (!valid) {
+      while (!valid && steps > 0) {
         this.textRect = this.computeTextRect();
         this.labelRect = this.computeLabelRect();
-
-        var rectPoints = this.getPoints();
 
         valid = true;
 
@@ -254,26 +282,18 @@ export default {
             continue;
           }
 
-          var elPoints = element.getPoints();
-
-          for (var p = 0; p < rectPoints.length; ++p) {
-            if (element.containsPoint(rectPoints[p])) {
-              valid = false;
-              break;
-            }
-
-            if (this.containsPoint(elPoints[p])) {
-              valid = false;
-              break;
-            }
+          if (collides(this.labelRect, element.labelRect)) {
+            valid = false;
+            break;
           }
         }
 
         if (!valid) {
-          this.center = positioners.moveFromAnchor(this.center, 1);
+          this.center = positioners.moveFromAnchor(this.center, 5);
         }
+
+        steps--;
       }
     };
-
-  }
+  },
 };

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,17 @@
+const chartStates = new WeakMap();
+
+export function getState(chart) {
+  let state = chartStates.get(chart);
+  if (!state) {
+    state = {
+      sizeChanged: false,
+      fitting: false,
+    };
+    chartStates.set(chart, state);
+  }
+  return state;
+}
+
+export function removeState(chart) {
+  chartStates.delete(chart);
+}


### PR DESCRIPTION
This PR adds some optimizations and improvements:

- Reduce performance bottleneck in the layout algorithm when the chart contains a lot of datasets, by setting a loop limit. This can lead to overlapping labels when there is a LOT of labels, but anyway in this case the chart may not be readable
- Improve the resizing algorithm to fit the labels in the chart area, by running successive fitting processes
- Avoid to draw labels if fitting is ongoing
- Rewrite the collision algorithm by making it more readable

